### PR TITLE
fixed column type error in CategoryDataGrid.php

### DIFF
--- a/src/Datagrids/CategoryDataGrid.php
+++ b/src/Datagrids/CategoryDataGrid.php
@@ -62,7 +62,7 @@ class CategoryDataGrid extends DataGrid
         $this->addColumn([
             'index'      => 'id',
             'label'      => trans('blog::app.datagrid.id'),
-            'type'       => 'number',
+            'type'       => 'integer',
             'searchable' => false,
             'sortable'   => true,
             'filterable' => true,


### PR DESCRIPTION
there was an error whre a type "number" got sent to the ColumnTypeEnum.php. The fix simply changes the type from "number" to "integer" to match the enum correct type.